### PR TITLE
add es6 support to nodejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,2 @@
-const app = require('./server/server');
-
-const port = 5000;
-
-app.listen(port, () => console.log(`Server running on port ${port}`));
+require = require("esm")(module/*, options*/)
+module.exports = require("./server/server.js").default

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express": "^4.16.3"
   },
   "devDependencies": {
+    "create-esm": "^1.0.5",
     "nodemon": "^1.17.3"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -1,8 +1,13 @@
-const express = require('express');
+import express from 'express';
 
 const app = express();
+
 app.get('/api/test', (req, res) => {
   res.send("OK");
 });
 
-module.exports = app;
+const port = 5000;
+
+app.listen(port, () => console.log(`Server running on port ${port}`));
+
+export default app;


### PR DESCRIPTION
Using "esm" allows writing es6 syntax in nodejs code.

Such as using "import" to replace "require()".

And please use es6 syntax at any place it can.

For more details, please checkout these:
https://github.com/standard-things/esm
https://www.youtube.com/watch?v=60S1PFndbn0